### PR TITLE
Handle secure cookies correctly behind proxies

### DIFF
--- a/config/middlewares.ts
+++ b/config/middlewares.ts
@@ -102,6 +102,7 @@ export default [
       key: 'koa.sess',
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
+      secureProxy: process.env.NODE_ENV === 'production',
       sameSite: 'lax',
       domain: 'hidezoneofficial.com',
       maxAge: 24 * 60 * 60 * 1000,

--- a/dist/config/middlewares.js
+++ b/dist/config/middlewares.js
@@ -89,6 +89,7 @@ exports.default = [
             key: 'koa.sess',
             httpOnly: true,
             secure: process.env.NODE_ENV === 'production',
+            secureProxy: process.env.NODE_ENV === 'production',
             sameSite: 'lax',
             domain: 'hidezoneofficial.com',
             maxAge: 24 * 60 * 60 * 1000,

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -17,7 +17,6 @@ exports.default = {
         // Ключи для подписи куки-сессий
         // Инициализируем Passport
         app.use(koa_passport_1.default.initialize());
-        app.use(koa_passport_1.default.session());
     },
     /**
      * В bootstrap-фазе настраиваем стратегию,
@@ -110,19 +109,19 @@ exports.default = {
             strapi.log.info(`   JWT issued for user ID=${user.id}`);
             // Поставить куку
             ctx.cookies.set('jwt', jwt, {
-                domain: 'hidezoneofficial.com',
-                path: '/api',
+                domain: "hidezoneofficial.onrender.com",
                 httpOnly: true,
-                secure: false,
-                sameSite: 'Lax',
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'None',
                 maxAge: 24 * 60 * 60 * 1000,
             });
             strapi.log.info('   Cookie "jwt" set');
-            // Редирект на фронтенд
-            ctx.redirect(process.env.APP_URL);
+            // Редирект на фронт
+            const redirectUrl = 'https://hidezoneofficial.com/';
+            ctx.redirect(redirectUrl);
         });
-        const MAIL_UID = 'api::mail.mail'; // TODO: замените на свой UID коллекции
-        // PATCH /api/mails/:id/mark-old
+        const MAIL_UID = 'api::mail.mail'; // заменишь на свой UID при необходимости
+        // ---------- PATCH /api/mails/:id/mark-old ----------
         router.patch('/api/mails/:id/mark-old', async (ctx) => {
             // 1) Проверяем JWT из куки
             const token = ctx.cookies.get('jwt');
@@ -354,23 +353,17 @@ exports.default = {
         });
         router.get('/api/auth/logout', async (ctx) => {
             strapi.log.info('→ GET /api/auth/logout');
-            // 1) Стираем jwt-куку на корне и на /api
             const cookieOptions = {
-                domain: 'hidezoneofficial.com',
+                domain: "hidezoneofficial.onrender.com",
                 httpOnly: true,
                 secure: process.env.NODE_ENV === 'production',
-                sameSite: 'Lax',
+                sameSite: 'None',
                 maxAge: 0,
             };
-            // удаляем на корневом пути
             ctx.cookies.set('jwt', null, { ...cookieOptions, path: '/' });
-            strapi.log.info('   jwt cookie cleared on path=/');
-            // удаляем на пути /api
             ctx.cookies.set('jwt', null, { ...cookieOptions, path: '/api' });
-            strapi.log.info('   jwt cookie cleared on path=/api');
-            // 2) Возвращаем клиенту 200 OK
-            ctx.body = { ok: true };
-            ctx.redirect(process.env.APP_URL);
+            strapi.log.info('   jwt cookie cleared');
+            ctx.redirect('https://hidezoneofficial.com/');
         });
         router.post('/api/blackhole/register', async (ctx) => {
             // 1) Auth

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,7 +139,7 @@ export default {
           ctx.cookies.set('jwt', jwt, {
             domain: "hidezoneofficial.onrender.com", // домен API
             httpOnly: true,
-            secure: true,      // обязателен с SameSite=None
+            secure: process.env.NODE_ENV === 'production', // обязателен с SameSite=None в проде
             sameSite: 'None',  // разные origin → нужна None
             maxAge: 24 * 60 * 60 * 1000,
             // domain и path НЕ указываем — кука принадлежит onrender-домену
@@ -518,7 +518,7 @@ export default {
       const cookieOptions = {
         domain: "hidezoneofficial.onrender.com",
         httpOnly: true,
-        secure: true,
+        secure: process.env.NODE_ENV === 'production',
         sameSite: 'None',
         maxAge: 0,
       };


### PR DESCRIPTION
## Summary
- add `secureProxy` to Koa session config
- send JWT cookies with `secure` only in production and remove unused session middleware

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a092bb5af483239a617495e68a32f8